### PR TITLE
Change observation.obs_event_field_concept_id to null

### DIFF
--- a/Sql Server/OMOP CDM sql server ddl.txt
+++ b/Sql Server/OMOP CDM sql server ddl.txt
@@ -511,7 +511,7 @@ CREATE TABLE observation
   unit_source_value				    VARCHAR(50)		NULL ,
   qualifier_source_value			VARCHAR(50)		NULL ,
   observation_event_id				BIGINT			NULL , 
-  obs_event_field_concept_id		INTEGER			NOT NULL , 
+  obs_event_field_concept_id		INTEGER			NULL , 
   value_as_datetime					DATETIME2		NULL
 )
 ;


### PR DESCRIPTION
observation.obs_event_field_concept_id is nullable per https://ohdsi.github.io/CommonDataModel/cdm60.html#OBSERVATION.

Synthea-ETL project to import data also requires this column to be null.